### PR TITLE
Include in_progress state as one that can be filled

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -114,7 +114,7 @@ function updateFactorialShifts() {
       .then(periods => {
         periods.forEach(
           ({ id: periodId, employee_id: employeeId, state, distribution }) => {
-            if (state !== "pending") return;
+            if (!['pending', 'in_progress'].includes(state)) return;
 
             let change = 0;
             request(


### PR DESCRIPTION
Factorial is returning `in_progress` instead of `pending` in some scenarios, this change allows us to add periods for `in_progress` months.