### PR TITLE
Fix script for people that has to validate shifts to others.

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -83,7 +83,6 @@ function request(url, config = { method: "GET", body: null, referrer: null }) {
       "accept-language": "en-US,en;q=0.9,ca;q=0.8,es;q=0.7",
       "cache-control": "no-cache",
       "content-type": "application/json;charset=UTF-8",
-      pragma: "no-cache",
       "sec-fetch-mode": "cors",
       "sec-fetch-site": "same-site"
     },

--- a/popup.js
+++ b/popup.js
@@ -157,9 +157,15 @@ function updateFactorialShifts() {
                 );
                 if (change > 0) chrome.tabs.reload(tabs[0].id);
                 window.close();
+              })
+              .catch((error) => {
+                console.log(error);
               });
           }
         );
+      })
+      .catch((error) => {
+        console.log(error);
       });
   });
 }


### PR DESCRIPTION
When you have to _validate_ shifts for someone, `periods` requests can include those, and then, when trying to update them in https://github.com/jaimevelaz/factorial-attendance/blob/51a83a6c5bf939f75edb6f8712c5ad6d9a11b33a/popup.js#L113-L114 the API returns 403 breaking the process.

This should _brute-force_ the problem
